### PR TITLE
Escape query parameters when getting canonical request

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -143,7 +143,9 @@ namespace Aws4RequestSigner
         {
             var querystring = HttpUtility.ParseQueryString(request.RequestUri.Query);
             var keys = querystring.AllKeys.OrderBy(a => a).ToArray();
-            var queryParams = keys.Select(key => $"{key}={querystring[key]}");
+
+            // Query params must be escaped in upper case (i.e. "%2C", not "%2c").
+            var queryParams = keys.Select(key => $"{key}={Uri.EscapeDataString(querystring[key])}");
             var canonicalQueryParams = string.Join("&", queryParams);
             return canonicalQueryParams;
         }


### PR DESCRIPTION
This PR fixes #2 by escaping query parameters in the request. Query parameters must be escaped in upper case.

Here's how the string-to-sign looks before and after the fix.
Before:
```
GET
/api
Action=UrlInfo&ResponseGroup=Rank,RankByCountry&Url=google.com
host:awis.us-west-1.amazonaws.com
x-amz-date:20181217T101437Z

host;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```
After:
```
GET
/api
Action=UrlInfo&ResponseGroup=Rank%2CRankByCountry&Url=google.com
host:awis.us-west-1.amazonaws.com
x-amz-date:20181217T101437Z

host;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```