### PR TITLE
HTML encode parts of URI

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -96,7 +96,8 @@ namespace Aws4RequestSigner
 
             var canonical_request = new StringBuilder();
             canonical_request.Append(request.Method + "\n");
-            canonical_request.Append(request.RequestUri.AbsolutePath + "\n");
+			canonical_request.Append(string.Join("/", request.RequestUri.AbsolutePath.Split("/")
+				.Select(pathPart => WebUtility.UrlEncode(pathPart))) + "\n");
 
             var canonicalQueryParams = GetCanonicalQueryParams(request);
 

--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -96,8 +96,7 @@ namespace Aws4RequestSigner
 
             var canonical_request = new StringBuilder();
             canonical_request.Append(request.Method + "\n");
-			canonical_request.Append(string.Join("/", request.RequestUri.AbsolutePath.Split("/")
-				.Select(pathPart => WebUtility.UrlEncode(pathPart))) + "\n");
+            canonical_request.Append(string.Join("/", request.RequestUri.AbsolutePath.Split("/").Select(pathPart => WebUtility.UrlEncode(pathPart))) + "\n");
 
             var canonicalQueryParams = GetCanonicalQueryParams(request);
 


### PR DESCRIPTION
Currently (at least with the version released on NuGet) requests to the WebSocket ApiGateway are not possible since AWS expects the parts of the URI (eg /@connections) to be HTML encoded (eg /%40connections).
This patch adds the encoding.