### PR TITLE
Sort header keys with OrdinalIgnoreCase

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -106,7 +106,7 @@ namespace Aws4RequestSigner
 
             var signedHeadersList = new List<string>();
 
-            foreach (var header in request.Headers.OrderBy(a => a.Key.ToLowerInvariant()))
+            foreach (var header in request.Headers.OrderBy(a => a.Key.ToLowerInvariant(), StringComparer.OrdinalIgnoreCase))
             {
                 canonical_request.Append(header.Key.ToLowerInvariant());
                 canonical_request.Append(":");


### PR DESCRIPTION
I've found a bug: 
The headers should be sorted alphabetically, but if you doesn't define the OrdinalIgnoreCase, this will fail:
If you have an `x-api-key` and a `x-apigw-api-id` the correct order should be:
1. `x-api-key`
2. `x-apigw-api-id`

Without the Ordinal_IgnoreCase_ option it would be:
1. `x-apigw-api-id`
2. `x-api-key`

It's not a must have, but I've run into this, and it took some hours to find where is it failing