### PR TITLE
Another fix required for correct signature using query string arrays

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -162,9 +162,12 @@ namespace Aws4RequestSigner
                 }
                 else
                 {
-                    // Query params must be escaped in upper case (i.e. "%2C", not "%2c").
                     // Handles multiple values per query parameter
-                    var queryValues = querystring[key].Split(',').Select(v => $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(v)}");
+                    var queryValues = querystring[key].Split(',')
+                        // Order by value alphanumerically (required for correct canonical string)
+                        .OrderBy(v => v)
+                        // Query params must be escaped in upper case (i.e. "%2C", not "%2c").
+                        .Select(v => $"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(v)}");
 
                     values.Add(Uri.EscapeDataString(key), queryValues);
                 }


### PR DESCRIPTION
One more fix is required to correctly generate canonical strings with query parameter arrays. 

Because the canonical string must be generated in a repeatable, consistent way, if a query parameter appears multiple times in the request, it must be ordered by it's value alphanumerically when generating the canonical string.

For example, if the request contains this query parameter array:

?ids=C&ids=A&ids=B

The canonical string must be:

?ids=A&ids=B&ids=C