### PR TITLE
Update AWS4RequestSigner.cs

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -151,7 +151,7 @@ namespace Aws4RequestSigner
 
         private static string GetCanonicalQueryParams(HttpRequestMessage request)
         {
-            var values = new SortedDictionary<string, IEnumerable<string>>(StringComparer.Ordinal);
+            var values = new SortedDictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
 
             var querystring = HttpUtility.ParseQueryString(request.RequestUri.Query);
             foreach (var key in querystring.AllKeys)

--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -151,7 +151,7 @@ namespace Aws4RequestSigner
 
         private static string GetCanonicalQueryParams(HttpRequestMessage request)
         {
-            var values = new SortedDictionary<string, IEnumerable<string>>();
+            var values = new SortedDictionary<string, IEnumerable<string>>(StringComparer.Ordinal);
 
             var querystring = HttpUtility.ParseQueryString(request.RequestUri.Query);
             foreach (var key in querystring.AllKeys)

--- a/Aws4Signer/Aws4RequestSigner.csproj
+++ b/Aws4Signer/Aws4RequestSigner.csproj
@@ -5,9 +5,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors />
     <Company />
-    <Version>1.0.1</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.2</Version>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
     <PackageLicenseUrl>https://github.com/tsibelman/aws-signer-v4-dot-net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/tsibelman/aws-signer-v4-dot-net</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>


### PR DESCRIPTION
Use `StringComparer.OrdinalIgnoreCase` when sorting query params

To add some more detail, query params need to be sorted by their "character code point".

> Sort the parameter names by character code point in ascending order. 

https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

The internal AWS4Signer also uses the `OrdinalIgnoreCase`

https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs#L843-L850