### PR TITLE
Update AWS4RequestSigner.cs Sort Comparer

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -151,7 +151,7 @@ namespace Aws4RequestSigner
 
         private static string GetCanonicalQueryParams(HttpRequestMessage request)
         {
-            var values = new SortedDictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+            var values = new SortedDictionary<string, IEnumerable<string>>(StringComparer.Ordinal);
 
             var querystring = HttpUtility.ParseQueryString(request.RequestUri.Query);
             foreach (var key in querystring.AllKeys)

--- a/Aws4Signer/Aws4RequestSigner.csproj
+++ b/Aws4Signer/Aws4RequestSigner.csproj
@@ -5,9 +5,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors />
     <Company />
-    <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
-    <FileVersion>1.0.2.0</FileVersion>
+    <Version>1.0.3</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <FileVersion>1.0.3.0</FileVersion>
     <PackageLicenseUrl>https://github.com/tsibelman/aws-signer-v4-dot-net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/tsibelman/aws-signer-v4-dot-net</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>


### PR DESCRIPTION
I recently made a change to the sort comparer for the query params to use the `StringComparer.OrdinalIgnoreCase` (see PR https://github.com/tsibelman/aws-signer-v4-dot-net/pull/29) instead of the default

`Ordinal` is required to satisfy AWS's requirements but `OrdinalIgnoreCase` was used instead to follow AWS's [internal signer](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Core/Amazon.Runtime/Internal/Auth/AWS4Signer.cs#L843-L850). 

We recently encountered a similar issue as before and discovered that the using "Ignore Case" was not producing the expected signature so we switched to `Ordinal` and that resolved the issue. The docs also mention briefly that casing is **NOT** ignore so I suspect that the AWS internal signer is incorrect.

> Sort the parameter names by character code point in ascending order. Parameters with duplicate names should be sorted by value. For example, a parameter name that begins with the uppercase letter F precedes a parameter name that begins with a lowercase letter b.
