### PR TITLE
Changed header value separator to match default used by .NET System.Net.Http

### DIFF
--- a/Aws4Signer/AWS4RequestSigner.cs
+++ b/Aws4Signer/AWS4RequestSigner.cs
@@ -127,7 +127,7 @@ namespace Aws4RequestSigner
             {
                 canonicalRequest.Append(header.Key.ToLowerInvariant());
                 canonicalRequest.Append(":");
-                canonicalRequest.Append(string.Join(",", header.Value.Select(s => s.Trim())));
+                canonicalRequest.Append(string.Join(", ", header.Value.Select(s => s.Trim())));
                 canonicalRequest.Append("\n");
                 signedHeadersList.Add(header.Key.ToLowerInvariant());
             }


### PR DESCRIPTION
The header value default separator used by `System.Net.Http` is `", "` - a comma followed by a space.  

The signing process needs to match this otherwise the signature will not match the headers as sent over the wire by `System.Net.Http`

Microsoft's decision can be seen in the .NET source code: [HttpHeaderParser.cs](https://github.com/dotnet/runtime/blob/9d4c65ddddb340cdb1479cafc6e320d1918c82eb/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs#L13C9-L13C53)